### PR TITLE
Added missing TestConverter class to fix build

### DIFF
--- a/zal.extractor.core/src/test/java/ir/co/bayan/simorq/zal/extractor/convert/TestConverter.java
+++ b/zal.extractor.core/src/test/java/ir/co/bayan/simorq/zal/extractor/convert/TestConverter.java
@@ -1,0 +1,10 @@
+package ir.co.bayan.simorq.zal.extractor.convert;
+
+public class TestConverter implements Converter {
+
+	@Override
+	public Object convert(String value) {
+		return value;
+	}
+
+}


### PR DESCRIPTION
First, thanks for creating a useful project. It looks like a test file may have gone missing at some point (multiple tests reference it), which caused the build on zal.extractor.core to fail; adding this test file fixed the issue, and I was able to use your extractor plugin.